### PR TITLE
Allows Progressive Alchemy to run without TOP

### DIFF
--- a/src/main/java/com/zerofall/progressivealchemy/ProgressiveAlchemy.java
+++ b/src/main/java/com/zerofall/progressivealchemy/ProgressiveAlchemy.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid = ProgressiveAlchemy.MODID, name = ProgressiveAlchemy.MODNAME, version = ProgressiveAlchemy.MODVERSION, dependencies = "required-after:projecte", useMetadata = true)
+@Mod(modid = ProgressiveAlchemy.MODID, name = ProgressiveAlchemy.MODNAME, version = ProgressiveAlchemy.MODVERSION, dependencies = "required-after:projecte;after:theoneprobe", useMetadata = true)
 public class ProgressiveAlchemy {
 
     public static final String MODID = "progressivealchemy";

--- a/src/main/java/com/zerofall/progressivealchemy/blocks/CondenserTieredBlock.java
+++ b/src/main/java/com/zerofall/progressivealchemy/blocks/CondenserTieredBlock.java
@@ -27,7 +27,10 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.fml.common.Optional;
 
+
+@Optional.Interface(iface = "mcjty.theoneprobe.api.IProbeInfoAccessor", modid = "theoneprobe") 
 public class CondenserTieredBlock extends Condenser implements IProbeInfoAccessor {
 	
 	private final int tier;
@@ -57,6 +60,7 @@ public class CondenserTieredBlock extends Condenser implements IProbeInfoAccesso
 		return true;
 	}
 	
+	@Optional.Method(modid="theoneprobe")
 	@Override
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world,
 			IBlockState blockState, IProbeHitData data) {


### PR DESCRIPTION
Should be pretty straightforward, but tl;dr I added TOP to the dependencies list to ensure it is loaded before progressive alchemy and added Optional annotations so that it doesn't break in the absence of TOP.  